### PR TITLE
Fix mint button show up when wallet is not connected

### DIFF
--- a/session-keys/src/app/page.tsx
+++ b/session-keys/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
             <CreateSession onSessionCreated={handleSessionCreated} />
           )}
 
-          {sessionData && (
+          {status === "connected" && sessionData && (
             <MintNft
               sessionSigner={sessionData.sessionSigner}
               session={sessionData.session}


### PR DESCRIPTION
Currently, if you have a session key but the wallet is not connected, you can still mint NFTs
<img width="536" alt="Screenshot 2025-01-16 at 11 20 58" src="https://github.com/user-attachments/assets/92902104-bbcf-4ddd-90f6-500d79358cf9" />

To fix it, just need to ensure the wallet is connected and there is a session active to allow the button to be displayed

Steps to reproduce:
1. Connect wallet
2. Create session keys
3. Mint NFT
4. Disconnect wallet
5. Mint NFT button still there
6. Click on it
7. Mints second NFT