### PR TITLE
fix: HTML closing tag and broken repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://mintlify.s3-us-west-1.amazonaws.com/abstract/images/Block.svg" width="700px" alt="abstract banner"/>
     <br />
     <h1>Abstract Examples</h1>
-    <p align="center">Cloneable starter templates & example repos to help kickstart your next project on Abstract.
+    <p align="center">Cloneable starter templates & example repos to help kickstart your next project on Abstract.</p> 
 </div>
 
 <br/>
@@ -26,5 +26,5 @@ Within each directory, you'll find a `README.md` file with instructions on how t
 | [Paymaster Smart Contract](https://github.com/Abstract-Foundation/examples/tree/main/paymasters)                                      | Build and deploy a paymaster smart contract that can sponsor the gas fees of transactions for other accounts on Abstract.           |
 | [Smart Contract Account](https://github.com/Abstract-Foundation/examples/tree/main/smart-contract-accounts)                           | Build your own basic smart contract wallet and submit transactions from it to use Abstract's native account abstraction.            |
 | [Smart Contract Account (with Viem)](https://github.com/Abstract-Foundation/examples/tree/main/smart-contract-accounts-viem)          | Build your own basic smart contract wallet and submit transactions from it to use Abstract's native account abstraction using Viem. |
-| [Smart Contract Account Factory](https://github.com/Abstract-Foundation/examples/tree/main/smart-contract-accounts-factory)           | Build a factory smart contract that can create smart contract accounts that have a single EOA signer.                               |
+| [Smart Contract Account Factory](https://github.com/Abstract-Foundation/examples/tree/main/smart-contract-account-factory)           | Build a factory smart contract that can create smart contract accounts that have a single EOA signer.                               |
 | [Session Keys](https://github.com/Abstract-Foundation/examples/tree/main/session-keys)                                                | Create and use temporary session keys with Abstract Global Wallet to execute pre-defined actions without repeated signing.           |


### PR DESCRIPTION
### Line 5:
**Added a closing `</p>` tag. This is a correct fix since in HTML all opening tags should have corresponding closing tags for proper document structure.**

Before:`<p align="center">Cloneable starter templates & example repos to help kickstart your next project on Abstract.`
After: `<p align="center">Cloneable starter templates & example repos to help kickstart your next project on Abstract.</p>`
### Fixed 404 in URL 
**Proper URL path should be "smart-contract-account-factory".**
Before:
![image](https://github.com/user-attachments/assets/193e2abd-bf9c-4601-928e-188465f1c370)
After:
![image](https://github.com/user-attachments/assets/c99150f1-8d49-4785-82c9-3e72081cd057)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `README.md` file to improve formatting and correct a link in the table of examples related to smart contract accounts.

### Detailed summary
- Corrected the closing tag for the paragraph in the introduction.
- Fixed the link for `Smart Contract Account Factory` to ensure it points to the correct path: `smart-contract-account-factory`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->