### PR TITLE
Improve local storage session keys for development

### DIFF
--- a/session-keys-local-storage/src/app/page.tsx
+++ b/session-keys-local-storage/src/app/page.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useEffect } from "react";
 import { useAbstractSession } from "@/hooks/useAbstractSession";
-import { useAccount } from "wagmi";
+import { useAccount, useDisconnect } from "wagmi";
 import styles from "./page.module.css";
 import LoginWithAGW from "@/components/LoginWithAGW";
 import chain from "@/config/chain";
+import { useAbstractClient } from "@abstract-foundation/agw-react";
 
 /**
  * Home Component
@@ -23,12 +24,14 @@ import chain from "@/config/chain";
  */
 export default function Home() {
   const { address, isConnected } = useAccount();
+  const { disconnect } = useDisconnect();
   const { getStoredSession, createAndStoreSession, clearStoredSession } =
     useAbstractSession(chain);
 
   const [sessionData, setSessionData] = useState<any>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [statusMessage, setStatusMessage] = useState<string>("");
+  const { data: client } = useAbstractClient();
 
   // Check for an existing session when the component mounts or wallet connects
   useEffect(() => {
@@ -40,7 +43,7 @@ export default function Home() {
         "Please connect your Abstract Global Wallet to use session keys"
       );
     }
-  }, [isConnected]);
+  }, [isConnected, client?.account?.address]); // we must wait for the client to be connected
 
   /**
    * Checks if there's an existing session stored in local storage
@@ -107,6 +110,14 @@ export default function Home() {
         `Error: ${error instanceof Error ? error.message : "Unknown error"}`
       );
     }
+  };
+
+  /**
+   * Handles user logout by disconnecting wallet
+   */
+  const handleLogout = () => {
+    disconnect();
+    setStatusMessage("Logged out successfully");
   };
 
   /**
@@ -191,6 +202,14 @@ export default function Home() {
                 disabled={isLoading || !sessionData}
               >
                 Clear Session
+              </button>
+              
+              <button
+                className={styles.button}
+                onClick={handleLogout}
+                disabled={isLoading}
+              >
+                Logout
               </button>
             </div>
 

--- a/session-keys-local-storage/src/app/page.tsx
+++ b/session-keys-local-storage/src/app/page.tsx
@@ -6,7 +6,7 @@ import { useAccount, useDisconnect } from "wagmi";
 import styles from "./page.module.css";
 import LoginWithAGW from "@/components/LoginWithAGW";
 import chain from "@/config/chain";
-import { useAbstractClient } from "@abstract-foundation/agw-react";
+import { useAbstractClient, useLoginWithAbstract } from "@abstract-foundation/agw-react";
 
 /**
  * Home Component
@@ -24,7 +24,7 @@ import { useAbstractClient } from "@abstract-foundation/agw-react";
  */
 export default function Home() {
   const { address, isConnected } = useAccount();
-  const { disconnect } = useDisconnect();
+  const { logout } = useLoginWithAbstract();
   const { getStoredSession, createAndStoreSession, clearStoredSession } =
     useAbstractSession(chain);
 
@@ -116,8 +116,7 @@ export default function Home() {
    * Handles user logout by disconnecting wallet
    */
   const handleLogout = () => {
-    disconnect();
-    setStatusMessage("Logged out successfully");
+    logout();
   };
 
   /**

--- a/session-keys-local-storage/src/app/page.tsx
+++ b/session-keys-local-storage/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useAbstractSession } from "@/hooks/useAbstractSession";
-import { useAccount, useDisconnect } from "wagmi";
+import { useAccount } from "wagmi";
 import styles from "./page.module.css";
 import LoginWithAGW from "@/components/LoginWithAGW";
 import chain from "@/config/chain";

--- a/session-keys-local-storage/src/config/chain.ts
+++ b/session-keys-local-storage/src/config/chain.ts
@@ -5,8 +5,7 @@ import { abstractTestnet, abstract } from "viem/chains";
  * Uses Abstract testnet in development and the mainnet in production.
  * In this simple example, we use the testnet in both environments.
  */
-const chain =
-  process.env.NODE_ENV === "development" ? abstractTestnet : abstractTestnet;
+const chain = process.env.NODE_ENV === "production" ? abstract : abstractTestnet;
 
 export type SupportedChain = typeof chain;
 

--- a/session-keys-local-storage/src/lib/constants.ts
+++ b/session-keys-local-storage/src/lib/constants.ts
@@ -38,8 +38,9 @@ export const SESSION_VALIDATOR_ABI = [
  *
  * The actual storage key is created by appending the user's wallet address to this prefix,
  * ensuring each wallet address has its own unique storage key.
+ * The prefix includes the current NODE_ENV to separate data between environments.
  */
-export const LOCAL_STORAGE_KEY_PREFIX = "abstract_session_";
+export const LOCAL_STORAGE_KEY_PREFIX = `abstract_session_${process.env.NODE_ENV || 'development'}_`;
 
 /**
  * @constant {string} ENCRYPTION_KEY_PREFIX
@@ -48,5 +49,6 @@ export const LOCAL_STORAGE_KEY_PREFIX = "abstract_session_";
  * The actual storage key is created by appending the user's wallet address to this prefix,
  * ensuring each wallet address has its own unique encryption key stored separately from the
  * encrypted session data.
+ * The prefix includes the current NODE_ENV to separate data between environments.
  */
-export const ENCRYPTION_KEY_PREFIX = "encryption_key_";
+export const ENCRYPTION_KEY_PREFIX = `encryption_key_${process.env.NODE_ENV || 'development'}_`;

--- a/session-keys-local-storage/src/lib/createAndStoreSession.ts
+++ b/session-keys-local-storage/src/lib/createAndStoreSession.ts
@@ -9,6 +9,24 @@ import { getEncryptionKey } from "./getEncryptionKey";
 import { encrypt } from "./encryptSession";
 
 /**
+ * Default call policies for session keys
+ * Defines which contract functions the session key can call and with what limits
+ */
+export const DEFAULT_CALL_POLICIES = [
+  {
+    target: "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA" as `0x${string}`, // NFT contract
+    selector: toFunctionSelector("mint(address,uint256)"),
+    valueLimit: {
+      limitType: LimitType.Unlimited,
+      limit: BigInt(0),
+      period: BigInt(0),
+    },
+    maxValuePerUse: BigInt(0),
+    constraints: [],
+  },
+];
+
+/**
  * @function createAndStoreSession
  * @description Creates a new Abstract Global Wallet session and stores it securely in local storage
  *
@@ -60,19 +78,7 @@ export const createAndStoreSession = async (
           limit: parseEther("1"),
           period: BigInt(0),
         },
-        callPolicies: [
-          {
-            target: "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA", // NFT contract
-            selector: toFunctionSelector("mint(address,uint256)"),
-            valueLimit: {
-              limitType: LimitType.Unlimited,
-              limit: BigInt(0),
-              period: BigInt(0),
-            },
-            maxValuePerUse: BigInt(0),
-            constraints: [],
-          },
-        ],
+        callPolicies: DEFAULT_CALL_POLICIES,
         transferPolicies: [],
       },
     });

--- a/session-keys-local-storage/src/lib/getStoredSession.ts
+++ b/session-keys-local-storage/src/lib/getStoredSession.ts
@@ -9,6 +9,7 @@ import { decrypt } from "./decryptSession";
 import { validateSession } from "./validateSession";
 import { SupportedChain } from "@/config/chain";
 import type { Address } from "viem";
+import { DEFAULT_CALL_POLICIES } from "./createAndStoreSession";
 
 /**
  * @function getStoredSession
@@ -56,6 +57,18 @@ export const getStoredSession = async (
     const key = await getEncryptionKey(address);
     const decryptedData = await decrypt(encryptedData, key);
     const parsedData = JSON.parse(decryptedData);
+    // IF DEFAULT_CALL_POLICIES have changed we return null
+    if (
+      JSON.stringify(parsedData.session.callPolicies, (_, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      ) !== 
+      JSON.stringify(DEFAULT_CALL_POLICIES, (_, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      )
+    ) {
+      return null;
+    }
+
     const sessionHash = getSessionHash(parsedData.session);
     await validateSession(abstractClient, address, sessionHash, chain, createSessionAsync);
     return parsedData;


### PR DESCRIPTION
Added option to logout
Session should load on refresh (wait for client)
Based on the network, the session keys should be recreated
Based on connected user, the session keys should be recreated
If policies change, then the session should be recreated

Makes development easier

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing session management and environment-specific configurations in the application. It introduces default call policies, modifies storage key prefixes based on the environment, and updates session handling in the `Home` component.

### Detailed summary
- Updated `chain` assignment in `chain.ts` for production environment.
- Added check for `DEFAULT_CALL_POLICIES` in `getStoredSession.ts`.
- Modified `LOCAL_STORAGE_KEY_PREFIX` and `ENCRYPTION_KEY_PREFIX` in `constants.ts` to include `NODE_ENV`.
- Introduced `DEFAULT_CALL_POLICIES` in `createAndStoreSession.ts`.
- Replaced hardcoded `callPolicies` with `DEFAULT_CALL_POLICIES` in `createAndStoreSession`.
- Added `useLoginWithAbstract` and `handleLogout` in `page.tsx`.
- Updated `useEffect` dependency to include `client?.account?.address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->