### PR TITLE
Reorder event call to emit correct accountAddress in AccountCreated event in AccountFactory example

### DIFF
--- a/smart-contract-account-factory/contracts/src/contracts/AccountFactory.sol
+++ b/smart-contract-account-factory/contracts/src/contracts/AccountFactory.sol
@@ -31,9 +31,9 @@ contract AccountFactory {
                 )
             );
         require(success, "Deployment failed");
-        emit AccountCreated(accountAddress, owner);
-
         (accountAddress) = abi.decode(returnData, (address));
+
+        emit AccountCreated(accountAddress, owner);
     }
 
     event AccountCreated(address indexed accountAddress, address indexed owner);


### PR DESCRIPTION
Reordered AccountCreated event call to ensure the AccountCreated event emits the correct accountAddress.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on the `AccountFactory` contract by ensuring that the `AccountCreated` event is emitted correctly after a new account is deployed.

### Detailed summary
- Added the emission of the `AccountCreated` event with `accountAddress` and `owner` after successful deployment.
- Declared the `AccountCreated` event with indexed parameters for `accountAddress` and `owner`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->